### PR TITLE
Bugfixes and contrib helpers, 0.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ async def app_factory():
     return app
 ```
 
+As a nice shortcut, use the [`aiohttp_oauth2/client/contrib.py`](aiohttp_oauth2/client/contrib.py) helpers to avoid needing to set the urls explicity.
+
 ### Examples
 
 Check the "examples" directory for working examples:

--- a/aiohttp_oauth2/__init__.py
+++ b/aiohttp_oauth2/__init__.py
@@ -1,37 +1,3 @@
-from typing import Any, Callable, Dict, List, Optional
+from .client import oauth2_app
 
-from aiohttp import ClientSession, web
-
-from .views import routes
-
-
-async def client_session(app: web.Application):
-    async with ClientSession() as session:
-        app["session"] = session
-        yield
-
-
-def oauth2_app(  # pylint: disable=too-many-arguments
-    client_id: str,
-    client_secret: str,
-    authorize_url: str,
-    token_url: str,
-    scopes: Optional[List[str]] = None,
-    on_login: Optional[Callable[[web.Request, Dict[str, Any]], web.Response]] = None,
-    on_error: Optional[Callable[[web.Request, str], web.Response]] = None,
-) -> web.Application:
-    app = web.Application()
-    app.update(  # pylint: disable=no-member
-        CLIENT_ID=client_id,
-        CLIENT_SECRET=client_secret,
-        AUTHORIZE_URL=authorize_url,
-        TOKEN_URL=token_url,
-        SCOPES=scopes,
-        ON_LOGIN=on_login,
-        ON_ERROR=on_error,
-    )
-    app.cleanup_ctx.append(client_session)
-
-    app.add_routes(routes)
-
-    return app
+__all__ = ("oauth2_app",)

--- a/aiohttp_oauth2/client/__init__.py
+++ b/aiohttp_oauth2/client/__init__.py
@@ -1,0 +1,41 @@
+from typing import Any, Callable, Dict, List, Optional
+
+from aiohttp import ClientSession, web
+
+from .views import routes
+
+
+async def client_session(app: web.Application):
+    async with ClientSession() as session:
+        app["session"] = session
+        yield
+
+
+def oauth2_app(  # pylint: disable=too-many-arguments
+    client_id: str,
+    client_secret: str,
+    authorize_url: str,
+    token_url: str,
+    scopes: Optional[List[str]] = None,
+    on_login: Optional[Callable[[web.Request, Dict[str, Any]], web.Response]] = None,
+    on_error: Optional[Callable[[web.Request, str], web.Response]] = None,
+) -> web.Application:
+    """
+    Factory to generate an aiohttp application configured as an oauth2 client.
+    """
+    app = web.Application()
+
+    app.update(  # pylint: disable=no-member
+        CLIENT_ID=client_id,
+        CLIENT_SECRET=client_secret,
+        AUTHORIZE_URL=authorize_url,
+        TOKEN_URL=token_url,
+        SCOPES=scopes,
+        ON_LOGIN=on_login,
+        ON_ERROR=on_error,
+    )
+    app.cleanup_ctx.append(client_session)
+
+    app.add_routes(routes)
+
+    return app

--- a/aiohttp_oauth2/client/__init__.py
+++ b/aiohttp_oauth2/client/__init__.py
@@ -1,41 +1,10 @@
-from typing import Any, Callable, Dict, List, Optional
-
-from aiohttp import ClientSession, web
-
-from .views import routes
-
-
-async def client_session(app: web.Application):
-    async with ClientSession() as session:
-        app["session"] = session
-        yield
+from .app import oauth2_app
+from .contrib import (
+    slack,
+)
 
 
-def oauth2_app(  # pylint: disable=too-many-arguments
-    client_id: str,
-    client_secret: str,
-    authorize_url: str,
-    token_url: str,
-    scopes: Optional[List[str]] = None,
-    on_login: Optional[Callable[[web.Request, Dict[str, Any]], web.Response]] = None,
-    on_error: Optional[Callable[[web.Request, str], web.Response]] = None,
-) -> web.Application:
-    """
-    Factory to generate an aiohttp application configured as an oauth2 client.
-    """
-    app = web.Application()
-
-    app.update(  # pylint: disable=no-member
-        CLIENT_ID=client_id,
-        CLIENT_SECRET=client_secret,
-        AUTHORIZE_URL=authorize_url,
-        TOKEN_URL=token_url,
-        SCOPES=scopes,
-        ON_LOGIN=on_login,
-        ON_ERROR=on_error,
-    )
-    app.cleanup_ctx.append(client_session)
-
-    app.add_routes(routes)
-
-    return app
+__all__ = (
+    "oauth2_app",
+    "slack",
+)

--- a/aiohttp_oauth2/client/__init__.py
+++ b/aiohttp_oauth2/client/__init__.py
@@ -1,10 +1,4 @@
 from .app import oauth2_app
-from .contrib import (
-    slack,
-)
 
 
-__all__ = (
-    "oauth2_app",
-    "slack",
-)
+__all__ = ("oauth2_app",)

--- a/aiohttp_oauth2/client/app.py
+++ b/aiohttp_oauth2/client/app.py
@@ -1,0 +1,43 @@
+from typing import Any, Callable, Dict, List, Optional
+
+from aiohttp import ClientSession, web
+
+from .views import routes
+
+
+async def client_session(app: web.Application):
+    async with ClientSession() as session:
+        app["session"] = session
+        yield
+
+
+def oauth2_app(  # pylint: disable=too-many-arguments
+    client_id: str,
+    client_secret: str,
+    authorize_url: str,
+    token_url: str,
+    scopes: Optional[List[str]] = None,
+    on_login: Optional[Callable[[web.Request, Dict[str, Any]], web.Response]] = None,
+    on_error: Optional[Callable[[web.Request, str], web.Response]] = None,
+    json_data=True,
+) -> web.Application:
+    """
+    Factory to generate an aiohttp application configured as an oauth2 client.
+    """
+    app = web.Application()
+
+    app.update(  # pylint: disable=no-member
+        CLIENT_ID=client_id,
+        CLIENT_SECRET=client_secret,
+        AUTHORIZE_URL=authorize_url,
+        TOKEN_URL=token_url,
+        SCOPES=scopes,
+        ON_LOGIN=on_login,
+        ON_ERROR=on_error,
+        DATA_AS_JSON=json_data,
+    )
+    app.cleanup_ctx.append(client_session)
+
+    app.add_routes(routes)
+
+    return app

--- a/aiohttp_oauth2/client/contrib.py
+++ b/aiohttp_oauth2/client/contrib.py
@@ -1,3 +1,4 @@
+# pylint: disable=invalid-name
 from functools import partial
 
 from .app import oauth2_app

--- a/aiohttp_oauth2/client/contrib.py
+++ b/aiohttp_oauth2/client/contrib.py
@@ -1,0 +1,29 @@
+from functools import partial
+
+from .app import oauth2_app
+
+
+github = partial(
+    oauth2_app,
+    authorize_url="https://github.com/login/oauth/authorize",
+    token_url="https://github.com/login/oauth/access_token",
+)
+
+google = partial(
+    oauth2_app,
+    authorize_url="https://accounts.google.com/o/oauth2/v2/auth",
+    token_url="https://www.googleapis.com/oauth2/v4/token",
+)
+
+slack = partial(
+    oauth2_app,
+    authorize_url="https://slack.com/oauth/authorize",
+    token_url="https://slack.com/api/oauth.access",
+    json_data=False,
+)
+
+twitter = partial(
+    oauth2_app,
+    authorize_url="https://api.twitter.com/oauth/authorize",
+    token_url="https://api.twitter.com/oauth2/token",
+)

--- a/aiohttp_oauth2/client/views.py
+++ b/aiohttp_oauth2/client/views.py
@@ -36,10 +36,9 @@ class CallbackView(web.View):
     Handle the oauth2 callback
     """
 
-
     async def get(self) -> web.Response:
         if self.request.query.get("error") is not None:
-            return self.handle_error(self.request, self.request.query["error"])
+            return await self.handle_error(self.request, self.request.query["error"])
 
         params = {
             "headers": {"Accept": "application/json"},
@@ -67,7 +66,7 @@ class CallbackView(web.View):
         handler = request.app.get("ON_ERROR")
         if handler is not None:
             return await handler(request)
-        raise web.HTTPServerError(f"Unhandled OAuth2 Error: {error}")
+        raise web.HTTPInternalServerError(text=f"Unhandled OAuth2 Error: {error}")
 
     async def handle_success(self, request, user_data):
         handler = request.app.get("ON_LOGIN")

--- a/aiohttp_oauth2/client/views.py
+++ b/aiohttp_oauth2/client/views.py
@@ -40,9 +40,7 @@ class CallbackView(web.View):
         if self.request.query.get("error") is not None:
             return await self.handle_error(self.request, self.request.query["error"])
 
-        params = {
-            "headers": {"Accept": "application/json"},
-        }
+        params = {"headers": {"Accept": "application/json"}}
         body = {
             "client_id": self.request.app["CLIENT_ID"],
             "client_secret": self.request.app["CLIENT_SECRET"],
@@ -55,8 +53,7 @@ class CallbackView(web.View):
             params["data"] = body
 
         async with self.request.app["session"].post(
-            self.request.app["TOKEN_URL"],
-            **params
+            self.request.app["TOKEN_URL"], **params
         ) as r:  # pylint: disable=invalid-name
             result = await r.json()
 

--- a/aiohttp_oauth2/client/views.py
+++ b/aiohttp_oauth2/client/views.py
@@ -41,15 +41,23 @@ class CallbackView(web.View):
         if self.request.query.get("error") is not None:
             return self.handle_error(self.request, self.request.query["error"])
 
+        params = {
+            "headers": {"Accept": "application/json"},
+        }
+        body = {
+            "client_id": self.request.app["CLIENT_ID"],
+            "client_secret": self.request.app["CLIENT_SECRET"],
+            "code": self.request.query["code"],
+            "redirect_uri": redirect_uri(self.request),
+        }
+        if self.request.app["DATA_AS_JSON"]:
+            params["json"] = body
+        else:
+            params["data"] = body
+
         async with self.request.app["session"].post(
             self.request.app["TOKEN_URL"],
-            headers={"Accept": "application/json"},
-            json={
-                "client_id": self.request.app["CLIENT_ID"],
-                "client_secret": self.request.app["CLIENT_SECRET"],
-                "code": self.request.query["code"],
-                "redirect_uri": redirect_uri(self.request),
-            },
+            **params
         ) as r:  # pylint: disable=invalid-name
             result = await r.json()
 

--- a/examples/github.py
+++ b/examples/github.py
@@ -8,7 +8,7 @@ from aiohttp_jinja2 import setup as jinja2_setup, template
 from aiohttp_session import SimpleCookieStorage, get_session, setup as session_setup
 
 
-from aiohttp_oauth2 import oauth2_app
+from aiohttp_oauth2.client.contrib import github
 
 
 @template("index.html")
@@ -45,11 +45,9 @@ def app_factory() -> web.Application:
 
     app.add_subapp(
         "/auth/github/",
-        oauth2_app(
+        github(
             "a1b8c7904865ac38baba",
             "147d82d8ded7a74899fcc4da2b61f8d305bf81c5",
-            "https://github.com/login/oauth/authorize",
-            "https://github.com/login/oauth/access_token",
             on_login=on_github_login,
         ),
     )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from setuptools import find_packages, setup
 
-__version__ = "0.0.2"
+__version__ = "0.0.3"
 
 with open(Path(__file__).parent / "README.md") as f:
     long_description = f.read()


### PR DESCRIPTION
Bugfixes:

1. Fix default handling of the `on_error` and `on_login` callbacks if users do not provide a callback

Features:

1. Add option to use form data instead of JSON for login, use the `json_data=False` parameter to `oauth2_app` to opt in (necessary for Slack)
1. Add `aiohttp_oauth2/client/contrib.py` for helpers for various oauth2 providers (github, google, slack, and twitter)
