### PR TITLE
Add configuration to force HTTPS for callbacks

### DIFF
--- a/aiohttp_oauth2/client/app.py
+++ b/aiohttp_oauth2/client/app.py
@@ -21,6 +21,7 @@ def oauth2_app(  # pylint: disable=too-many-arguments
     on_error: Optional[Callable[[web.Request, str], web.Response]] = None,
     json_data=True,
     auth_extras=None,
+    force_ssl=False,
 ) -> web.Application:
     """
     Factory to generate an aiohttp application configured as an oauth2 client.
@@ -40,6 +41,7 @@ def oauth2_app(  # pylint: disable=too-many-arguments
                       False will use Form Data instead.
     :param auth_extras: If the oauth2 provider supports non-standard parameters this is
                         a way to provide them to the authorization request.
+    :param force_ssl: Force the callback URL to use the https scheme.
     """
     app = web.Application()
 
@@ -53,6 +55,7 @@ def oauth2_app(  # pylint: disable=too-many-arguments
         ON_ERROR=on_error,
         DATA_AS_JSON=json_data,
         AUTH_EXTRAS=auth_extras or {},
+        FORCE_SSL=force_ssl,
     )
     app.cleanup_ctx.append(client_session)
 

--- a/aiohttp_oauth2/client/views.py
+++ b/aiohttp_oauth2/client/views.py
@@ -5,7 +5,11 @@ routes = web.RouteTableDef()  # pylint: disable=invalid-name
 
 
 def redirect_uri(request):
-    return str(request.url.with_path(str(request.app.router["callback"].url_for())))
+    callback = str(request.app.router["callback"].url_for())
+    url = request.url.with_path(str(callback))
+    if request.app["FORCE_SSL"]:
+        url = url.with_scheme("https")
+    return str(url)
 
 
 @routes.view("/auth", name="auth")


### PR DESCRIPTION
When aiohttp is run behind a reverse proxy with SSL termination the
URLs generated have http as the scheme breaking the redirect pattern
and possible validation on the oauth provider side.