### PR TITLE
If request body is not JSON it is likely a form

### DIFF
--- a/aiohttp_oauth2/client/views.py
+++ b/aiohttp_oauth2/client/views.py
@@ -53,7 +53,7 @@ class CallbackView(web.View):
         if self.request.app["DATA_AS_JSON"]:
             params["json"] = body
         else:
-            params["data"] = body
+            params["data"] = aiohttp.FormData(tuple(body.items()))
 
         async with self.request.app["session"].post(
             self.request.app["TOKEN_URL"], **params


### PR DESCRIPTION
Working with Azure AD the POST has to be of
'application/x-www-form-urlencoded'.

Slack also supports forms
https://api.slack.com/legacy/oauth#using_tokens