### PR TITLE
Include state if defined in the request query.

### DIFF
--- a/aiohttp_oauth2/client/views.py
+++ b/aiohttp_oauth2/client/views.py
@@ -27,6 +27,9 @@ class AuthView(web.View):
         if self.request.app["SCOPES"]:
             params["scope"] = " ".join(self.request.app["SCOPES"])
 
+        if "state" in self.request.query:
+            params["state"] = self.request.query["state"]
+
         location = str(URL(self.request.app["AUTHORIZE_URL"]).with_query(params))
 
         return web.HTTPTemporaryRedirect(location=location)


### PR DESCRIPTION
State can be passed with something like:

```py
raise web.HTTPFound("/auth?state=%s" % state)
```
